### PR TITLE
available formats for order items

### DIFF
--- a/back/api/models.py
+++ b/back/api/models.py
@@ -463,6 +463,12 @@ class OrderItem(models.Model):
         db_table = 'order_item'
         verbose_name = _('order_item')
 
+    @property
+    def available_formats(self):
+        queryset = ProductFormat.objects.filter(
+            product=self.product).values_list('data_format__name', flat=True)
+        return list(queryset)
+
     def _get_price_values(self, price_value):
         if self.price_status == OrderItem.PricingStatus.PENDING:
             return None

--- a/back/api/serializers.py
+++ b/back/api/serializers.py
@@ -163,6 +163,8 @@ class OrderItemSerializer(serializers.ModelSerializer):
         queryset=Product.objects.all(),
         slug_field='label')
 
+    available_formats = serializers.ListField(read_only=True)
+
     class Meta:
         model = OrderItem
         exclude = ['_price_currency', '_price', '_base_fee_currency',

--- a/back/api/tests/test_order.py
+++ b/back/api/tests/test_order.py
@@ -114,6 +114,7 @@ class OrderTests(APITestCase):
         self.assertEqual(response.data['items'][0]['product'], data['items'][0]['product'], 'Check product')
         self.assertEqual(
             response.data['items'][0]['price_status'], OrderItem.PricingStatus.CALCULATED, 'Check price is calculated')
+        self.assertIsNotNone(response.data['items'][0]['available_formats'], 'Check available formats are present')
 
         order_item_id = response.data['items'][0]['id']
         # Confirm order without format should not work


### PR DESCRIPTION
This PR adds `available_formats` property to order_items:

```json
            "id": 32057,
            "price": "20.00",
            "data_format": "3dm (Fichier Rhino)",
            "product": "Maquette 3D",
            "available_formats": [
                "3dm (Fichier Rhino)",
                "IFC (BIM model file)"
            ],
            "srid": 2056,
            "price_status": "CALCULATED",
            "order": 11466
```
