### PR TITLE
Extract prod

### DIFF
--- a/back/.pylintrc
+++ b/back/.pylintrc
@@ -15,7 +15,7 @@ ignore-patterns=
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-#init-hook=
+#init-hook=test_*
 
 # Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
 # number of processors available to use.

--- a/back/api/admin.py
+++ b/back/api/admin.py
@@ -108,7 +108,8 @@ class ProductAdmin(CustomModelAdmin):
 
 
 class AbstractIdentityAdmin(CustomModelAdmin):
-    search_fields = ['first_name', 'last_name', 'company_name']
+    list_display = ['last_name', 'first_name', 'company_name', 'email']
+    search_fields = ['first_name', 'last_name', 'company_name', 'email']
 
 
 class PricingAdmin(CustomModelAdmin):

--- a/back/api/management/commands/fixturize.py
+++ b/back/api/management/commands/fixturize.py
@@ -27,7 +27,7 @@ class Command(BaseCommand):
         extract_permission.save()
 
         extract_user = UserModel.objects.create_user(
-            username='extract', password=os.environ['EXTRACT_USER_PASSWORD'])
+            username='sitn_extract', password=os.environ['EXTRACT_USER_PASSWORD'])
         extract_group.permissions.add(extract_permission)
         extract_group.save()
         extract_user.groups.add(extract_group)

--- a/back/api/models.py
+++ b/back/api/models.py
@@ -18,12 +18,6 @@ LOGGER = logging.getLogger(__name__)
 # Get the UserModel
 UserModel = get_user_model()
 
-# Get a better name for Users based on their identities
-def get_name(self):
-    if self.identity:
-        return '{} ({} {})'.format(self.identity.email, self.identity.first_name, self.identity.last_name)
-    return '{}'.format(self.username)
-UserModel.add_to_class("__str__", get_name)
 
 class AbstractIdentity(models.Model):
     """

--- a/back/api/tests/test_extract.py
+++ b/back/api/tests/test_extract.py
@@ -83,7 +83,7 @@ class OrderTests(APITestCase):
 
         url = reverse('token_obtain_pair')
         resp = self.client.post(
-            url, {'username': 'extract', 'password': os.environ['EXTRACT_USER_PASSWORD']}, format='json')
+            url, {'username': 'sitn_extract', 'password': os.environ['EXTRACT_USER_PASSWORD']}, format='json')
         self.token = resp.data['access']
         resp = self.client.post(url, {'username':'private_user_order', 'password':'testPa$$word'}, format='json')
         self.client_token = resp.data['access']

--- a/back/api/tests/test_order.py
+++ b/back/api/tests/test_order.py
@@ -291,7 +291,7 @@ class OrderTests(APITestCase):
         self.assertEqual(len(response.data['items']), 2, 'Two products are present')
         response = self.client.patch(url, data1, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
-        self.assertEqual(len(response.data['items']), 1, 'One product is present')
+        self.assertEqual(len(response.data['items']), 2, 'Two products are still present')
         response = self.client.put(url, self.order_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
         self.assertEqual(len(response.data['items']), 0, 'No product is present')

--- a/front/src/app/_components/cart-overlay/cart-overlay.component.scss
+++ b/front/src/app/_components/cart-overlay/cart-overlay.component.scss
@@ -1,6 +1,5 @@
 :host {
   height: 100%;
-  width: 250px;
   display: flex;
   flex-direction: column;
 
@@ -27,4 +26,8 @@
   .action-button {
     margin-top: 10px;
   }
+}
+/* larger cart panel */
+::ng-deep.mat-menu-panel {
+  max-width: 350px !important;
 }

--- a/front/src/app/_components/cart-overlay/cart-overlay.component.ts
+++ b/front/src/app/_components/cart-overlay/cart-overlay.component.ts
@@ -1,4 +1,4 @@
-import {Component, HostBinding, OnDestroy, OnInit} from '@angular/core';
+import {Component, HostBinding, OnDestroy, OnInit, EventEmitter, Output} from '@angular/core';
 import {AppState, isLoggedIn, selectOrder} from '../../_store';
 import {Store} from '@ngrx/store';
 import * as fromCart from '../../_store/cart/cart.action';
@@ -23,6 +23,8 @@ import {GeoshopUtils} from '../../_helpers/GeoshopUtils';
   styleUrls: ['./cart-overlay.component.scss']
 })
 export class CartOverlayComponent implements OnInit, OnDestroy {
+
+  @Output() refreshOrders = new EventEmitter<number | null>();
 
   @HostBinding('class') class = 'overlay-container';
 
@@ -57,6 +59,14 @@ export class CartOverlayComponent implements OnInit, OnDestroy {
 
   removeProduct(label: string) {
     const order = GeoshopUtils.deepCopyOrder(this.order);
+    const orderItem = order.items.filter(x => Order.getProductLabel(x) === label)[0];
+    if (orderItem.id) {
+      this.apiOrderService.deleteOrderItem(orderItem.id).subscribe(confirmed => {
+        if (confirmed) {
+          this.refreshOrders.emit(this.order.id);
+        }
+      });
+    }
     order.items = order.items.filter(x => Order.getProductLabel(x) !== label);
     this.store.dispatch(fromCart.updateOrder({order}));
   }

--- a/front/src/app/_helpers/GeoshopUtils.ts
+++ b/front/src/app/_helpers/GeoshopUtils.ts
@@ -58,6 +58,7 @@ export class GeoshopUtils {
           }
           const newItem: IOrderItem = {
             product: newProduct,
+            product_id: item.product_id,
             data_format: item.data_format,
             available_formats: item.available_formats,
             id: item.id,

--- a/front/src/app/_models/IIdentity.ts
+++ b/front/src/app/_models/IIdentity.ts
@@ -12,11 +12,6 @@ export interface IIdentity {
   url?: string;
   password1?: string;
   password2?: string;
-  last_login?: Date;
-  is_superuser?: boolean;
-  is_staff?: boolean;
-  is_active?: boolean;
-  date_joined?: Date;
   street?: string;
   street2?: string;
   postcode?: string;

--- a/front/src/app/_models/IOrder.ts
+++ b/front/src/app/_models/IOrder.ts
@@ -30,7 +30,7 @@ export type OrderStatus = 'DRAFT' |
 
 export interface IOrderItem {
   product: IProduct | string;
-
+  product_id: number;
   id?: number;
   price?: string;
   data_format?: string;
@@ -48,7 +48,7 @@ export interface IOrderToPost {
   description: string;
   geom: string | undefined;
   invoice_reference?: string;
-  invoice_contact: number | null;
+  invoice_contact?: number | null;
   items: IOrderItem[];
 }
 
@@ -221,19 +221,16 @@ export class Order {
       this.id = -1;
     }
 
-    for (let i = 0; i < this.items.length; i++) {
-      const item = this.items[i];
+    for (const item of this.items) {
       const product = item.product;
       if (typeof product === 'string') {
         item.product = {
+          id: item.product_id,
           label: product
         };
       }
       this._isAllOrderItemCalculated = this._isAllOrderItemCalculated && item.price_status === 'CALCULATED';
     }
-
-    // @ts-ignore
-    this.items.sort((a, b) => a.product.label < b.product.label ? -1 : a.product.label < b.product.label ? 1 : 0);
 
     this.initializeGeometry(options.geom);
     this.statusAsReadableIconText = Order.initializeStatus(options, this._isAllOrderItemCalculated);

--- a/front/src/app/_models/IProduct.ts
+++ b/front/src/app/_models/IProduct.ts
@@ -3,6 +3,7 @@
 import {IMetadata} from './IMetadata';
 
 export interface IProduct {
+  id: number;
   url?: string;
   label: string;
   status?: string;

--- a/front/src/app/_models/IUser.ts
+++ b/front/src/app/_models/IUser.ts
@@ -19,9 +19,7 @@ export interface IUserToPost {
 
 export interface IUser {
   id: number;
-  last_login: string;
   username: string;
-  date_joined: string;
   identity_id: number;
   first_name: string;
   last_name: string;

--- a/front/src/app/_services/api-order.service.ts
+++ b/front/src/app/_services/api-order.service.ts
@@ -253,12 +253,50 @@ export class ApiOrderService {
       );
   }
 
+  updateOrderItemsDataFormats(order: Order): Observable<IOrder | null> {
+    if (!this.apiUrl) {
+      this.apiUrl = this.configService.config.apiUrl;
+    }
+
+    const url = new URL(`${this.apiUrl}/order/${order.id}/`);
+
+    return this.http.patch<IOrder | null>(url.toString(), {
+      items: order.items.map(x => {
+        x.product = Order.getProductLabel(x);
+        if (!x.data_format) {
+          delete x.data_format;
+        }
+        return x;
+      })
+    })
+      .pipe(
+        catchError(() => {
+          return of(null);
+        })
+      );
+  }
+
   delete(orderId: number) {
     if (!this.apiUrl) {
       this.apiUrl = this.configService.config.apiUrl;
     }
 
     const url = new URL(`${this.apiUrl}/order/${orderId}/`);
+
+    return this.http.delete<boolean>(url.toString()).pipe(
+      map(() => true),
+      catchError(() => {
+        return of(false);
+      })
+    );
+  }
+
+  deleteOrderItem(orderItemId: number) {
+    if (!this.apiUrl) {
+      this.apiUrl = this.configService.config.apiUrl;
+    }
+
+    const url = new URL(`${this.apiUrl}/orderitem/${orderItemId}/`);
 
     return this.http.delete<boolean>(url.toString()).pipe(
       map(() => true),

--- a/front/src/app/_services/api.service.ts
+++ b/front/src/app/_services/api.service.ts
@@ -56,6 +56,21 @@ export class ApiService {
       );
   }
 
+  getProduct(productid: number) {
+    if (!this.apiUrl) {
+      this.apiUrl = this.configService.config.apiUrl;
+    }
+
+    const url = new URL(`${this.apiUrl}/product/${productid}/`);
+
+    return this.http.get<IProduct>(url.toString())
+      .pipe(
+        catchError(() => {
+          return of(null);
+        })
+      );
+  }
+
   loadMetadata(urlAsString?: string): Observable<IMetadata | null> {
     if (!urlAsString) {
       return of(null);

--- a/front/src/app/_services/store.service.ts
+++ b/front/src/app/_services/store.service.ts
@@ -33,18 +33,16 @@ export class StoreService {
       }));
       return;
     }
+    // Creates an array of observables (GET of each product in order)
+    const observables = order.items.map(x => this.apiService.getProduct(x.product_id));
 
-    const observables = order.items.map(x => this.apiService.find<IProduct>(Order.getProductLabel(x), 'product'));
-
+    // for every observable
     forkJoin(observables).subscribe(results => {
-      for (const result of results) {
-        if (result) {
-          for (const product of result.results) {
-
-            for (const item of order.items) {
-              if (Order.getProductLabel(item) === product.label) {
-                item.product = product;
-              }
+      for (const product of results) {
+        if (product) {
+          for (const item of order.items) {
+            if (Order.getProductLabel(item) === product.label) {
+              item.product = product;
             }
           }
         }

--- a/front/src/app/account/new-order/new-order.component.html
+++ b/front/src/app/account/new-order/new-order.component.html
@@ -225,11 +225,11 @@
     <form *ngIf="currentOrder" [formGroup]="orderItemFormGroup" (submit)="confirm()">
 
       <div class="table-container">
-        <table mat-table [dataSource]="dataSource">
+        <table mat-table [dataSource]="dataSource" matSort>
 
           <!-- Label Column -->
           <ng-container matColumnDef="label">
-            <th mat-header-cell *matHeaderCellDef style="width: 30%;">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>
               Description / Disponibilité
             </th>
             <td mat-cell *matCellDef="let orderItem">
@@ -252,7 +252,16 @@
 
           <!-- Format Column -->
           <ng-container matColumnDef="format">
-            <th mat-header-cell *matHeaderCellDef>Format</th>
+            <th mat-header-cell *matHeaderCellDef>
+                <mat-select formControlName="formatsForAll" placeholder="Même format pour tous les produits"
+                 (selectionChange)="updateAllDataFormats()">
+                  <mat-option *ngFor="let format of allAvailableFormats" [value]="format">
+                    {{ format }}
+                  </mat-option>
+                </mat-select>
+                <mat-spinner *ngIf="isOrderPatchLoading" diameter="16" color="accent"
+                           style="margin-right: 10px"></mat-spinner>
+            </th>
             <td mat-cell *matCellDef="let orderItem">
               <mat-form-field color="primary">
                 <mat-select [formControlName]="getOrderItemControlName(orderItem)" required

--- a/front/src/app/account/new-order/new-order.component.scss
+++ b/front/src/app/account/new-order/new-order.component.scss
@@ -104,6 +104,10 @@
         -webkit-hyphens: auto;
         hyphens: auto;
       }
+
+      .mat-form-field {
+        width: 100%;
+      }
     }
   }
 }

--- a/front/src/app/welcome/catalog/catalog.component.ts
+++ b/front/src/app/welcome/catalog/catalog.component.ts
@@ -100,9 +100,15 @@ export class CatalogComponent implements OnInit {
 
   addToCart(product: IProduct) {
     const order = GeoshopUtils.deepCopyOrder(this.order);
-    order.items.push({
-      product
-    });
+    const itemsInCart = order.items.map(x => x.product_id);
+    if (itemsInCart.indexOf(product.id) === -1) {
+      order.items.push({
+        product,
+        product_id: product.id
+      });
+    } else {
+      this.snackBar.open('Le produit est déjà dans le panier', 'Fermer', {duration: 3000});
+    }
     this.store.dispatch(updateOrder({order}));
   }
 

--- a/front/src/app/welcome/map/map.component.ts
+++ b/front/src/app/welcome/map/map.component.ts
@@ -168,7 +168,6 @@ export class MapComponent implements OnInit {
     });
 
     dialogRef.afterClosed().subscribe(result => {
-      console.log('The dialog was closed');
       if (result) {
         this.selectedPageFormat = result.selectedPageFormat;
         this.selectedPageFormatScale = result.selectedPageFormatScale;


### PR DESCRIPTION
This PR, for backend:
 - enhances Identity view in admin
 - changes default extract user to sitn_extract
 - reverts WKTLatLong to WKT (Long, Lat), don't ask...
 - handles better order_items when a PUT or PATCH is done on /orders

In front:
 - larger cart overlay
 - `DELETE` on orderitem when you press the delete button in cart
 - replaces calls to `/product/?search=<product_label>` by `/product/<product_id>`
 - deletes unused old identity properties
 - do not let user add the same product twice in cart
 - adds possibility to change formats for all items in cart:
 
![image](https://user-images.githubusercontent.com/3328875/107939072-84d84980-6f86-11eb-8ec3-5738d6d64012.png)
