### PR TITLE
User email

### DIFF
--- a/back/api/admin.py
+++ b/back/api/admin.py
@@ -122,12 +122,13 @@ class UserAdmin(BaseUserAdmin):
     list_display = ['username', 'identity_first_name', 'identity_last_name', 'identity_email']
     inlines = [IdentityInline]
     fieldsets = (
-        (None, {'fields': ('username', 'password')}),
+        (None, {'fields': ('username', 'password', 'email')}),
         (_('Permissions'), {
             'fields': ('is_active', 'is_staff', 'is_superuser', 'groups', 'user_permissions'),
         }),
         (_('Important dates'), {'fields': ('last_login', 'date_joined')}),
     )
+    readonly_fields = ('email',)
 
     def identity_first_name(self, user):
         return user.identity.first_name

--- a/back/api/management/commands/prepareusertests.py
+++ b/back/api/management/commands/prepareusertests.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
         rincevent.identity.country = 'Suisse'
         rincevent.identity.company_name = 'Service du Registre Foncier et de la Géomatique - SITN'
         rincevent.identity.phone = '+41 32 000 00 00'
-        rincevent.save()
+        rincevent.identity.save()
 
         mmi = UserModel.objects.create_user(
             username='mmi', password='mmi')
@@ -50,7 +50,7 @@ class Command(BaseCommand):
         mmi.identity.country = 'Suisse'
         mmi.identity.company_name = 'Service du Registre Foncier et de la Géomatique - SITN'
         mmi.identity.phone = '+41 32 000 00 00'
-        mmi.save()
+        mmi.identity.save()
 
         mma = UserModel.objects.create_user(
             username='mma', password='mma')
@@ -63,7 +63,7 @@ class Command(BaseCommand):
         mma.identity.country = 'Suisse'
         mma.identity.company_name = 'Service du Registre Foncier et de la Géomatique - SITN'
         mma.identity.phone = '+41 32 000 00 00'
-        mma.save()
+        mma.identity.save()
 
         mka = UserModel.objects.create_user(
             username='mka', password='mka')
@@ -77,7 +77,7 @@ class Command(BaseCommand):
         mka.identity.company_name = 'Service du Registre Foncier et de la Géomatique - SITN'
         mka.identity.phone = '+41 32 000 00 00'
         mka.identity.subscribed = True
-        mka.save()
+        mka.identity.save()
 
         # contacts
         contact1 = Contact.objects.create(

--- a/back/api/signals.py
+++ b/back/api/signals.py
@@ -11,6 +11,12 @@ def create_user_profile(sender, instance, created, **kwargs):
     if created and Identity.objects.filter(user=instance).first() is None:
         Identity.objects.create(user=instance)
 
-@receiver(post_save, sender=UserModel)
-def save_user_profile(sender, instance, **kwargs):
-    instance.identity.save()
+@receiver(post_save, sender=Identity)
+def copy_identity_email(sender, instance, **kwargs):
+    """
+    Copy Identity.email to UserModel.email because auth functions are based
+    UserModel.email
+    """
+    if instance.user:
+        instance.user.email = instance.email
+        instance.user.save()

--- a/back/api/templates/email_password_reset.html
+++ b/back/api/templates/email_password_reset.html
@@ -1,10 +1,11 @@
 {% extends "email_base_template.html" %}
+{% load i18n %}
 {% block content %}
-{% blocktranslate %}You're receiving this email because you requested a password reset for your user account at {{ site_name }}.{% endblocktranslate %}
+{% blocktrans %}You're receiving this email because you requested a password reset for your user account at {{ site_name }}.{% endblocktrans %}
 
-{% translate "Please go to the following page and choose a new password:" %}
+{% trans "Please go to the following page and choose a new password:" %}
 {% block reset_link %}
 {{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
 {% endblock %}
-{% translate 'Your username, in case you’ve forgotten:' %} {{ user.get_username }}
+{% trans 'Your username, in case you’ve forgotten:' %} {{ user.get_username }}
 {% endblock %}

--- a/back/api/tests/test_identity.py
+++ b/back/api/tests/test_identity.py
@@ -16,7 +16,7 @@ class ItentityViewsTests(APITestCase):
             password="testPa$$word",
         )
         self.userPublic.identity.is_public = True
-        self.userPublic.save()
+        self.userPublic.identity.save()
         self.userPrivate = UserModel.objects.create_user(
             username="private_user",
             password="testPa$$word",

--- a/back/api/tests/test_order.py
+++ b/back/api/tests/test_order.py
@@ -231,7 +231,7 @@ class OrderTests(APITestCase):
     def test_post_order_subscribed(self):
         sub_user = UserModel.objects.get(username='private_user_order')
         sub_user.identity.subscribed = True
-        sub_user.save()
+        sub_user.identity.save()
 
         url = reverse('order-list')
         self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.token)

--- a/back/api/tests/test_pricing.py
+++ b/back/api/tests/test_pricing.py
@@ -17,6 +17,7 @@ class PricingTests(APITestCase):
         rincevent = UserModel.objects.create_user(
             username='rincevent', password='rincevent')
         rincevent.identity.email = 'admin@admin.com'
+        rincevent.identity.save()
         self.base_fee = Money(50, 'CHF')
         self.unit_price = Money(150, 'CHF')
         self.pricings = Pricing.objects.bulk_create([

--- a/back/api/tests/test_user.py
+++ b/back/api/tests/test_user.py
@@ -18,7 +18,7 @@ class UserChangeTests(APITestCase):
             password="testPa$$word",
         )
         self.user.identity.is_public = True
-        self.user.save()
+        self.user.identity.save()
 
         self.admin = UserModel.objects.create_user(
             username="admin_user",

--- a/back/settings.py
+++ b/back/settings.py
@@ -179,6 +179,7 @@ if os.environ.get('GDAL_IN_VENV', None) == "True":
 FRONT_URL = os.environ["FRONT_URL"]
 FRONT_HREF = os.environ["FRONT_HREF"]
 CSRF_COOKIE_DOMAIN = os.environ["CSRF_COOKIE_DOMAIN"]
+CSRF_COOKIE_PATH = os.environ["FRONT_HREF"]
 CSRF_TRUSTED_ORIGINS = os.environ["ALLOWED_HOST"].split(",")
 CORS_ORIGIN_WHITELIST = [
     os.environ["FRONT_PROTOCOL"] + '://' + os.environ["FRONT_URL"],

--- a/front/copy-config.ps1
+++ b/front/copy-config.ps1
@@ -5,7 +5,7 @@ $snapshot = (Get-Content ($FilePath) | ConvertFrom-Json)
 $apiKey = "apiUrl"
 $mediaKey = "mediaUrl"
 
-$apiUrl = "https://sitn.ne.ch/geoshop2_prepub_api"
+$apiUrl = "http://localhost:8000/"
 $mediaUrl = "https://sitn.ne.ch/geoshop2_media/"
 
 Invoke-Expression ('$snapshot.' + $apiKey + "='" + $apiUrl + "'")

--- a/front/package.json
+++ b/front/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "copy /y \"src\\assets\\configs\\config.json.tmpl\" \"%cd%\\src\\assets\\configs\\config.json\" && powershell -file \"%cd%\\copy-config.ps1\" && start /b start-chrome.bat && ng serve",
+    "start": "copy /y \"src\\assets\\configs\\config.json.tmpl\" \"%cd%\\src\\assets\\configs\\config.json\" && powershell -file \"%cd%\\copy-config.ps1\" && ng serve",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",

--- a/front/src/app/_components/account-overlay/account-overlay.component.html
+++ b/front/src/app/_components/account-overlay/account-overlay.component.html
@@ -28,7 +28,7 @@
 </ng-container>
 
 <ng-container *ngIf="!(isLoggedIn$|async)">
-  <div class="flex-row info-container">
+  <div class="flex-row info-container px-16">
     <mat-icon>info</mat-icon>
     <span>Pour commander vous devez obligatoirement vous authentifier.</span>
   </div>

--- a/front/src/app/_components/account-overlay/account-overlay.component.scss
+++ b/front/src/app/_components/account-overlay/account-overlay.component.scss
@@ -4,6 +4,10 @@
   display: flex;
   flex-direction: column;
 
+  .px-16 {
+    padding: 0 16px;
+  }
+
   .name-container {
     padding: 0 15px;
     margin-bottom: 10px;

--- a/front/src/app/auth/forget/forget.component.html
+++ b/front/src/app/auth/forget/forget.component.html
@@ -1,9 +1,6 @@
 <mat-card>
-  <mat-card-header>
-    <div mat-card-avatar class="card-header-image"></div>
     <mat-card-title>GeoShop - Authentification</mat-card-title>
     <mat-card-subtitle>Mot de passe oublié</mat-card-subtitle>
-  </mat-card-header>
   <mat-card-content>
     <div class="flex-row info-container">
       <mat-icon>info</mat-icon>

--- a/front/src/app/auth/forget/forget.component.scss
+++ b/front/src/app/auth/forget/forget.component.scss
@@ -3,20 +3,13 @@
   justify-content: center;
   align-items: center;
 
-  .info-container {
-    width: 300px;
-  }
-
-  .card-header-image {
-    background-size: cover;
-    background-image: url("../../../assets/favicon.png");
+  mat-card {
+    max-width: 350px;
   }
 
   form {
     display: flex;
     flex-direction: column;
-    width: 300px;
-    padding: 15px;
 
     .form-login-button {
       margin-top: 15px;

--- a/front/src/app/auth/reset/reset.component.html
+++ b/front/src/app/auth/reset/reset.component.html
@@ -1,6 +1,5 @@
 <mat-card>
   <mat-card-header>
-    <div mat-card-avatar class="card-header-image"></div>
     <mat-card-title>GeoShop - Authentification</mat-card-title>
     <mat-card-subtitle>Réinitialiser son mot de passe</mat-card-subtitle>
   </mat-card-header>

--- a/front/src/styles.scss
+++ b/front/src/styles.scss
@@ -1,4 +1,5 @@
 /* You can add global styles to this file, and also import other style files */
+@import './theme.scss';
 
 html,
 body {
@@ -72,12 +73,11 @@ ul {
 }
 
 .info-container {
-  margin: 10px;
-  padding: 5px;
-  border: solid 1px #4177F6;
+  color: mat-color($accent);
+  margin: 1em 0;
 
   mat-icon {
-    color: #4177F6;
+    color: mat-color($accent);
     margin-right: 10px;
   }
 }


### PR DESCRIPTION
This PR:
 - Sets email on User when email on Identity is changed (the `signals.py` is like postgres triggers). email on User is very handy because all auth stuff is based on that. But we also need email on Identity and we have identities without users. That's why we keep the email in both models and sync them.
 - Sets CSRF cookie href (so we don't mix cookies with geoportal, or prepub)
 - Small cosmetic changes on front