### PR TITLE
Simplify large geometry

### DIFF
--- a/back/settings.py
+++ b/back/settings.py
@@ -143,7 +143,7 @@ USE_TZ = True
 
 SITE_ID = 2
 
-VAT = 0.076
+VAT = 0.077
 
 # Django REST specific configuration
 # https://www.django-rest-framework.org/
@@ -187,4 +187,8 @@ DEFAULT_PRODUCT_THUMBNAIL_URL = 'default_product_thumbnail.png'
 DEFAULT_METADATA_IMAGE_URL = 'default_metadata_image.png'
 AUTO_LEGEND_URL = os.environ.get('AUTO_LEGEND_URL', '')
 INTRA_LEGEND_URL = os.environ.get('INTRA_LEGEND_URL', '')
+
+# Geometries settings
+DEFAULT_SRID = 2056
+EXTRACT = 2056
 DEFAULT_SRID = 2056

--- a/front/src/app/welcome/map/map.component.ts
+++ b/front/src/app/welcome/map/map.component.ts
@@ -55,7 +55,7 @@ export class MapComponent implements OnInit {
   selectedPageFormat: IPageFormat;
   selectedPageFormatScale: number;
   rotationPageFormat: number;
-  pageFormatScales: Array<number> = [500, 1000, 1500, 2000, 3000];
+  pageFormatScales: Array<number> = [500, 1000, 2000, 5000];
 
   // Geocoder
   formGeocoder = new FormGroup({


### PR DESCRIPTION
This PR:
 - Simplifies large polygons
 - Use of real VAT (7.7%)
 - Only takes xy coordinates when a polygon is submitted. Because KML import can have 3D coordinates
 - Only use scales from Chantal