### PR TITLE
Duplicate draft

### DIFF
--- a/back/api/tests/test_order.py
+++ b/back/api/tests/test_order.py
@@ -155,6 +155,8 @@ class OrderTests(APITestCase):
         url = reverse('orderitem-detail', kwargs={'pk':order_item_id})
         response = self.client.patch(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertEqual(response.data['status'], OrderItem.OrderItemStatus.PENDING, 'status is PENDING')
+
 
         # Confirm order with format should work
         url = reverse('order-confirm', kwargs={'pk':order_id})
@@ -264,6 +266,7 @@ class OrderTests(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.token)
         response = self.client.post(url, self.order_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+        self.assertEqual(response.data['status'], Order.OrderStatus.DRAFT, 'status is DRAFT')
         order_id = response.data['id']
         # PATCH order with a product
         data1 = {
@@ -276,6 +279,7 @@ class OrderTests(APITestCase):
         url = reverse('order-detail', kwargs={'pk':order_id})
         response = self.client.patch(url, data1, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertEqual(response.data['status'], Order.OrderStatus.DRAFT, 'status is DRAFT')
         self.assertEqual(len(response.data['items']), 1, 'One product is present')
         data2 = {
             "items": [

--- a/back/api/views.py
+++ b/back/api/views.py
@@ -361,6 +361,7 @@ class ExtractOrderView(views.APIView):
     def get(self, request, *args, **kwargs):
         # Start by getting orderitems that are PENDING and that will be extracted by current user
         order_items = OrderItem.objects.filter(
+            Q(order__status=Order.OrderStatus.READY) &
             Q(product__provider=request.user) &
             Q(status=OrderItem.OrderItemStatus.PENDING)
         ).all()

--- a/front/src/app/_models/IOrder.ts
+++ b/front/src/app/_models/IOrder.ts
@@ -29,6 +29,12 @@ export type OrderStatus = 'DRAFT' |
   'REJECTED' |
   'CONFIRM_REQUIRED';
 
+export type OrderItemStatus = 'PENDING' |
+  'IN_EXTRACT' |
+  'PROCESSED' |
+  'ARCHIVED' |
+  'REJECTED';
+
 export interface IOrderItem {
   product: IProduct | string;
   product_id: number;
@@ -40,7 +46,7 @@ export interface IOrderItem {
   price_status?: PricingStatus;
   /** id of the order   */
   order?: number;
-  status?: OrderStatus;
+  status?: OrderItemStatus;
 }
 
 export interface IOrderToPost {


### PR DESCRIPTION
This fixes a bug introduced with #249 where Extract would fetch all pending order_items without taking care of order status.