### PR TITLE
fix validation pending during long time

### DIFF
--- a/back/api/models.py
+++ b/back/api/models.py
@@ -551,24 +551,27 @@ class Order(models.Model):
                 self.status = Order.OrderStatus.READY
         else:
             if OrderItem.OrderItemStatus.PROCESSED in items_statuses:
-                self.status = Order.OrderStatus.PROCESSED
-                self.date_processed = timezone.now()
-                send_geoshop_email(
-                    _('Geoshop - Download ready'),
-                    recipient=self.email_deliver or self.client.identity,
-                    template_name='email_download_ready',
-                    template_data={
-                        'order_id': self.id,
-                        'download_guid': self.download_guid,
-                        'front_url': '{}://{}{}'.format(
-                            settings.FRONT_PROTOCOL,
-                            settings.FRONT_URL,
-                            settings.FRONT_HREF
-                            ),
-                        'first_name': self.client.identity.first_name,
-                        'last_name': self.client.identity.last_name,
-                    }
-                )
+                if OrderItem.OrderItemStatus.VALIDATION_PENDING in items_statuses:
+                    self.status = Order.OrderStatus.PARTIALLY_DELIVERED
+                else:
+                    self.status = Order.OrderStatus.PROCESSED
+                    self.date_processed = timezone.now()
+                    send_geoshop_email(
+                        _('Geoshop - Download ready'),
+                        recipient=self.email_deliver or self.client.identity,
+                        template_name='email_download_ready',
+                        template_data={
+                            'order_id': self.id,
+                            'download_guid': self.download_guid,
+                            'front_url': '{}://{}{}'.format(
+                                settings.FRONT_PROTOCOL,
+                                settings.FRONT_URL,
+                                settings.FRONT_HREF
+                                ),
+                            'first_name': self.client.identity.first_name,
+                            'last_name': self.client.identity.last_name,
+                        }
+                    )
             else:
                 self.status = Order.OrderStatus.REJECTED
         return self.status

--- a/back/api/serializers.py
+++ b/back/api/serializers.py
@@ -398,7 +398,7 @@ class ProductSerializer(serializers.ModelSerializer):
     class Meta:
         model = Product
         read_only_fields = ['pricing', 'label', 'group']
-        exclude = ['order', 'thumbnail_link', 'ts', 'metadata']
+        exclude = ['order', 'thumbnail_link', 'ts', 'metadata', 'geom']
 
 
 class ProductExtractSerializer(ProductSerializer):


### PR DESCRIPTION
This PR fixes a bug: after all products are extracted but there's still one product that needs validation, the order status should remain `PARTIALLY_DELIVERED` and not switch to `PROCESSED`. There's a chroned task that such ordered products do not stay too long waiting for validation.
