### PR TITLE
fix metadata visibility

### DIFF
--- a/back/api/permissions.py
+++ b/back/api/permissions.py
@@ -1,4 +1,5 @@
 from rest_framework import permissions
+from django.conf import settings
 
 
 class ExtractGroupPermission(permissions.BasePermission):
@@ -17,7 +18,7 @@ class InternalGroupObjectPermission(permissions.BasePermission):
     """
 
     def has_object_permission(self, request, view, obj):
-        if obj.accessibility in ['PUBLIC', 'APPROVAL_NEEDED']:
+        if obj.accessibility in settings.METADATA_PUBLIC_ACCESSIBILITIES:
             return True
         if request.user.has_perm('api.view_internal'):
             return True

--- a/back/api/tests/test_metadata.py
+++ b/back/api/tests/test_metadata.py
@@ -2,17 +2,16 @@ from django.urls import reverse
 from django.contrib.auth.models import Group
 from rest_framework import status
 from rest_framework.test import APITestCase
-from api.models import Metadata
 from api.tests.factories import BaseObjectsFactory
+from django.contrib.auth.models import Permission
 
-
-class OrderTests(APITestCase):
+class MetadataTests(APITestCase):
     """
-    Test Orders
+    Test Metadata
     """
 
     def setUp(self):
-        self.config = BaseObjectsFactory(self.client)
+        self.config = BaseObjectsFactory()
 
     def test_view_public(self):
         """
@@ -24,14 +23,17 @@ class OrderTests(APITestCase):
         self.assertEqual(response.data['count'], 1, 'Only one public metadata is visible')
 
     def test_view_private(self):
-        self.config.user_private
         self.client.login(
             username=self.config.private_username,
             password=self.config.password
         )
         internal_group = Group.objects.get(name='internal')
+        permission = Permission.objects.get(codename='view_internal')
+        internal_group.permissions.add(permission)
+        internal_group.save()
         self.config.user_private.groups.add(internal_group)
         self.config.user_private.save()
+        self.assertEqual(self.config.user_private.has_perm('api.view_internal'), True)
         url = reverse('metadata-list')
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)

--- a/back/api/views.py
+++ b/back/api/views.py
@@ -135,7 +135,6 @@ class MetadataViewSet(viewsets.ReadOnlyModelViewSet):
     `public` and `approval needed` metadatas can be viewed by everyone.
     All metadatas can be accessed only by users belonging to `intranet` group.
     """
-    queryset = Metadata.objects.all()
     permission_classes = [InternalGroupObjectPermission]
     serializer_class = MetadataSerializer
     lookup_field = 'id_name'
@@ -157,6 +156,13 @@ class MetadataViewSet(viewsets.ReadOnlyModelViewSet):
         response['Access-Control-Allow-Origin'] = '*'
         response['Content-Security-Policy'] = 'frame-ancestors *'
         return response
+
+    def get_queryset(self):
+        user = self.request.user
+        has_permision = user.has_perm('api.view_internal')
+        if has_permision:
+            return Metadata.objects.all()
+        return Metadata.objects.filter(accessibility__in=settings.METADATA_PUBLIC_ACCESSIBILITIES)
 
     def get_serializer_context(self):
         context = super(MetadataViewSet, self).get_serializer_context()

--- a/back/settings.py
+++ b/back/settings.py
@@ -229,3 +229,6 @@ INTRA_LEGEND_URL = os.environ.get('INTRA_LEGEND_URL', '')
 
 # Geometries settings
 DEFAULT_SRID = 2056
+
+# Controls values of metadata accessibility field that will turn the metadata public
+METADATA_PUBLIC_ACCESSIBILITIES = ['PUBLIC', 'APPROVAL_NEEDED']


### PR DESCRIPTION
Django Rest Framework object level permissions are not applied on list views so internal metadata should be hidden by queryset