### PR TITLE
fix fts search config

### DIFF
--- a/back/api/filters.py
+++ b/back/api/filters.py
@@ -1,6 +1,7 @@
 import re
 import unidecode
 
+from django.conf import settings
 from django.contrib.postgres.search import SearchQuery
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
@@ -58,7 +59,11 @@ class FullTextSearchFilter(BaseFilterBackend):
         if not ts_field or not search_term:
             return queryset
 
-        search_query = SearchQuery(search_term, search_type='raw')
+        search_query = SearchQuery(
+            search_term,
+            search_type='websearch',
+            config=settings.SPECIAL_DATABASE_CONFIG['FTS_SEARCH_CONFIG']
+        )
 
         kwargs = {ts_field: search_query}
         queryset = queryset.filter(**kwargs)

--- a/back/settings.py
+++ b/back/settings.py
@@ -108,6 +108,13 @@ DATABASES = {
     }
 }
 
+# Special needs for geoshop running on PostgreSQL
+SPECIAL_DATABASE_CONFIG = {
+    # A search config with this name must exist on your database, please refer to
+    # https://www.postgresql.org/docs/current/textsearch-intro.html#TEXTSEARCH-INTRO-CONFIGURATIONS
+    'FTS_SEARCH_CONFIG': 'fr'
+}
+
 
 # Password validation
 # https://docs.djangoproject.com/en/3.0/ref/settings/#auth-password-validators


### PR DESCRIPTION
Fixes search configuration. It was not using 'fr' while ts_vector was created with 'fr'. Thats why "cadastre souterrain" never showed up.