### PR TITLE
Add a debounce time to the create TileLayer

### DIFF
--- a/front/src/app/_services/map.service.ts
+++ b/front/src/app/_services/map.service.ts
@@ -232,7 +232,16 @@ export class MapService {
     this.map.updateSize();
   }
 
+  private debounce(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
   public async createTileLayer(baseMapConfig: IBasemap, isVisible: boolean): Promise<TileLayer<TileSource> | undefined> {
+    if (!this.resolutions || !this.initialExtent) {
+      this.resolutions = this.configService.config!.resolutions;
+      this.initialExtent = this.configService.config!.initialExtent;
+      await this.debounce(200);
+    }
     const matrixIds = [];
     for (let i = 0; i < this.resolutions.length; i += 1) {
       matrixIds.push(`${i}`);


### PR DESCRIPTION
This PR fixes a bug that was introduced on a previous PR. I change the way of adding a WMTS layer some months ago. WMTS layers were based on their WMTSGetCapabilities XML. The map need to wait to parse all the XML before rendering.

Switching it to hard coded options, emproved performance of the map but now it was to quick and there was a conflict between the map and the WMTS layer. The WMTS layer was being added to the map before the map was fully ready. This PR add a little debounce to fix this problem.