### PR TITLE
needed for download details

### DIFF
--- a/back/api/serializers.py
+++ b/back/api/serializers.py
@@ -393,8 +393,8 @@ class PublicOrderSerializer(OrderSerializer):
     client = PublicUserIdentitySerializer(read_only=True)
     class Meta(OrderSerializer.Meta):
         exclude = [
-            'date_downloaded', 'extract_result', 'download_guid',
-            'processing_fee_currency', 'processing_fee', 'total_with_vat']
+            'date_downloaded', 'extract_result', 'download_guid'
+        ]
 
 
 class ProductSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Closes #334 

`'processing_fee_currency', 'processing_fee', 'total_with_vat'` are needed for the download page protected by UUID because details of the price are shown there.