### PR TITLE
fix fts not using raw

### DIFF
--- a/back/api/filters.py
+++ b/back/api/filters.py
@@ -61,7 +61,7 @@ class FullTextSearchFilter(BaseFilterBackend):
 
         search_query = SearchQuery(
             search_term,
-            search_type='websearch',
+            search_type='raw',
             config=settings.SPECIAL_DATABASE_CONFIG['FTS_SEARCH_CONFIG']
         )
 

--- a/back/settings.py
+++ b/back/settings.py
@@ -181,6 +181,11 @@ LOGGING = {
             'level': os.getenv('LOGGING_LEVEL', 'ERROR'),
             'propagate': False,
         },
+        # uncomment this for DB logging
+        #'django.db.backends': {
+        #    'level': 'DEBUG',
+        #    'handlers': ['console'],
+        #}
     },
 }
 


### PR DESCRIPTION
Because we build the search term ourself, we must use `raw` if we want the search to work on uncompleted words.

```python
    def get_search_term(self, request):
        """
        Search term is set by a ?search=... query parameter.
        This sanitizes the term so it can be passed to database.
        """
        term = request.query_params.get(self.search_param, '')
        term = term.replace('\x00', '')  # strip null characters
        term = re.sub(r'[!\'()|&:]', ' ', term).strip()
        term = unidecode.unidecode(term)
        if term:
            term = re.sub(r'\s+', ' & ', term)
            # Support prefix search on the last word. A tsquery of 'toda:*' will
            # match against any words that start with 'toda', which is good for
            # search-as-you-type.
            term += ':*'
        return term
```

Deployed in prepub:
https://sitn.ne.ch/geoshop2_prepub_api/product/?search=eau%20pot

Not working on prod:
https://sitn.ne.ch/geoshop2_api/product/?search=eau%20pot