### PR TITLE
fix geocat_link not visible

### DIFF
--- a/back/api/templates/metadata.html
+++ b/back/api/templates/metadata.html
@@ -88,7 +88,7 @@
                 {% endfor %}
               </td>
             </tr>
-            {% if documents %}
+            {% if documents or geocat_link %}
             <tr>
               <td>
                 Liens


### PR DESCRIPTION
This PR fixes that geocat_link was not visible if documents were not attached to a metadata